### PR TITLE
Cory

### DIFF
--- a/configs/msseg2.py
+++ b/configs/msseg2.py
@@ -77,9 +77,9 @@ def get_context(device, variables, fold=0, **kwargs):
     context.add_component("dataset", SubjectFolder, root='$DATASET_PATH', subject_path="",
                           subject_loader=subject_loader, cohorts=cohorts, transforms=transforms)
     context.add_component("model", NestedResUNet, input_channels=2, output_channels=2,
-                          filters=20, dropout_p=0.2, saggital_split=False)
+                          filters=40, dropout_p=0.2, saggital_split=False)
     context.add_component("optimizer", SGD, params="self.model.parameters()", lr=0.01, momentum=0.95)
-    context.add_component("criterion", HybridLogisticDiceLoss)
+    context.add_component("criterion", HybridLogisticDiceLoss, logistic_class_weights=[1, 2500])
 
     training_evaluators = [
         ScheduledEvaluation(evaluator=SegmentationEvaluator('y_pred_eval', 'y_eval'),

--- a/loggers/wandb_logger.py
+++ b/loggers/wandb_logger.py
@@ -48,6 +48,7 @@ class WandbLogger(Logger):
             wandb_params['id'] = context.metadata["wandb_id"] = wandb.util.generate_id()
             rw = RandomWords()
             context.name = f'{context.name}-{rw.random_word()}-{rw.random_word()}-{context.metadata["wandb_id"]}'
+            wandb_params['name'] = context.name
             wandb_params['config'] = context.get_config()
         else:
             wandb_params['id'] = context.metadata["wandb_id"]


### PR DESCRIPTION
- Fixed a bug where the validation set was reduced to 2 subjects instead of 8 in the training loop.
- wandb run name is properly set now (so it matches the context and checkpoint folder name)
- Loss function is cleaned up
- Logistic and dice terms are summed together after doing the mean instead of when they are still (N, C) tensors (idk if this even matters?)
- Logistic weights are normalized to sum to 1. So you cant change the total scale of the logistic term with weighting, just class balance.
- Epsilon on the logistic term is applied in a way that makes more sense (prevents inf loss).
- Added a hyper-param to not square the dice term. nnUNet suggests to not square, (based on intuition, no solid experiment).
- Determined a logistic weighting of 2500 for the lesion voxels. This is roughly the mean brain_voxel:lesion_voxel ratio across the training set.
- Increased the filters from 20 to 40 as it looks like we were using less than half of GPU memory on a v100.
